### PR TITLE
fix: support both local and production Docker builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,10 @@
+version: '3.8'
+
 services:
   app:
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: ghcr.io/splooshai/hello-world:latest
     container_name: hello-world
     restart: unless-stopped


### PR DESCRIPTION
# Description

This PR updates the docker-compose.yml to support both local development and production deployments. The changes enable:
- Local development: Build directly from Dockerfile without requiring GHCR authentication
- Production: Use pre-built multi-platform images from GitHub Container Registry
- Seamless transition between development and production environments
- Consistent image naming across all environments

This solves the authentication errors in local development while maintaining our production deployment capabilities.

## Type of Change

version: fix     # Bug fix (patch version bump)

## Testing

- [ ] I have tested these changes locally using `act`
- [ ] All existing tests pass
- [ ] My commits are signed with GPG