### PR TITLE
ci: temporarily disable deployment workflow and update documentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,8 @@ jobs:
           cache-to: type=gha,mode=max
 
   deploy:
+    # Temporarily disabled until coordination with infrastructure team
+    if: false  # This condition ensures the job is skipped
     needs: build-and-push
     runs-on: ubuntu-latest
     

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "cSpell.words": [
+        "appleboy",
+        "Buildx",
         "nodemon",
         "splooshai"
     ]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ docker-compose up --build
 
 > **Note:** Automatic deployment is temporarily disabled until coordination with the infrastructure team for project setup is complete.
 
+**Important Context:** This hello-world project is technically configured for deployment to the Sploosh.AI environment as a subdomain and project. However, since this repository serves primarily as a template and reference implementation, the deployment workflow has been intentionally disabled to prevent accidental deployments from unsuspecting engineers.
+
 To deploy this application:
 
 1. Contact the infrastructure team to set up the necessary deployment environment

--- a/README.md
+++ b/README.md
@@ -10,3 +10,17 @@ cd examples/hello-world
 
 # Build and run locally
 docker-compose up --build
+
+```
+
+## Deployment
+
+> **Note:** Automatic deployment is temporarily disabled until coordination with the infrastructure team for project setup is complete.
+
+To deploy this application:
+
+1. Contact the infrastructure team to set up the necessary deployment environment
+2. Once the environment is ready, the deployment workflow will be re-enabled by removing the `if: false` condition in the GitHub workflow
+3. After re-enabling, pushes to the main branch will automatically deploy to the production environment
+
+This repository is available as a public template in the SplooshAI GitHub organization.


### PR DESCRIPTION
# Description

This PR temporarily disables the deployment workflow for the hello-world project until coordination with the infrastructure team for project setup is complete. It also updates the README with important context about the deployment capabilities.

## Changes:
- Added `if: false` condition to the deploy job in the GitHub workflow to disable automatic deployments
- Updated README to inform users about the disabled deployment status
- Added context explaining that while deployment is technically configured, it's intentionally disabled to prevent accidental deployments

## Type of Change

version: ci       # CI/CD changes

## Testing

- [x] I have tested these changes locally using `act`
- [x] All existing tests pass
- [x] My commits are signed with GPG